### PR TITLE
perf(queue): skip unused server status checks

### DIFF
--- a/shared/src/main/java/net/pistonmaster/pistonqueue/shared/config/Config.java
+++ b/shared/src/main/java/net/pistonmaster/pistonqueue/shared/config/Config.java
@@ -327,6 +327,19 @@ public final class Config {
     return Collections.unmodifiableList(kickWhenDownServers);
   }
 
+  public Set<String> serversRequiringOnlineChecks() {
+    Set<String> servers = new LinkedHashSet<>();
+    if (pauseQueueIfTargetDown) {
+      for (QueueGroup group : queueGroupList) {
+        servers.addAll(group.targetServers());
+      }
+    }
+    if (kickWhenDown) {
+      servers.addAll(kickWhenDownServers);
+    }
+    return Collections.unmodifiableSet(servers);
+  }
+
   public boolean ifTargetDownSendToQueue() {
     return ifTargetDownSendToQueue;
   }

--- a/shared/src/main/java/net/pistonmaster/pistonqueue/shared/plugin/PistonQueuePlugin.java
+++ b/shared/src/main/java/net/pistonmaster/pistonqueue/shared/plugin/PistonQueuePlugin.java
@@ -73,7 +73,8 @@ public interface PistonQueuePlugin {
     final QueueGroup defaultGroup = config.getDefaultGroup();
     // Sends the position message and updates tab on an interval in chat
     schedule(() -> {
-      boolean targetsOnline = defaultGroup.targetServers().stream().anyMatch(queueListener.getServerStatusManager().getOnlineServers()::contains);
+      boolean targetsOnline = !config.pauseQueueIfTargetDown()
+        || defaultGroup.targetServers().stream().anyMatch(queueListener.getServerStatusManager().getOnlineServers()::contains);
       if (targetsOnline) {
         for (QueueType type : config.getAllQueueTypes()) {
           if (config.positionMessageChat()) {
@@ -109,9 +110,13 @@ public interface PistonQueuePlugin {
     // Moves the queue when someone logs off the target server on an interval set in the config.yml
     schedule(queueListener::moveQueue, config.queueMoveDelay(), config.queueMoveDelay(), TimeUnit.MILLISECONDS);
 
-    // Checks the status of all the servers
+    // Checks the status of servers used by enabled availability features
     schedule(() -> {
-      List<String> servers = new ArrayList<>(config.kickWhenDownServers());
+      Set<String> servers = config.serversRequiringOnlineChecks();
+      queueListener.getServerStatusManager().retainServers(servers);
+      if (servers.isEmpty()) {
+        return;
+      }
       CountDownLatch latch = new CountDownLatch(servers.size());
       for (String server : servers) {
         CompletableFuture.runAsync(() -> {

--- a/shared/src/main/java/net/pistonmaster/pistonqueue/shared/queue/ServerStatusManager.java
+++ b/shared/src/main/java/net/pistonmaster/pistonqueue/shared/queue/ServerStatusManager.java
@@ -39,6 +39,10 @@ public class ServerStatusManager {
       .collect(Collectors.toSet());
   }
 
+  public void retainServers(Set<String> servers) {
+    onlinePingCounts.keySet().removeIf(server -> !servers.contains(server));
+  }
+
   // For testing purposes so we can assert there is no overflow risk
   public int getOnlinePingCount(String server) {
     return onlinePingCounts.getOrDefault(server, 0);

--- a/shared/src/test/java/net/pistonmaster/pistonqueue/shared/config/ConfigTest.java
+++ b/shared/src/test/java/net/pistonmaster/pistonqueue/shared/config/ConfigTest.java
@@ -159,6 +159,37 @@ class ConfigTest {
   }
 
   @Test
+  void skipsOnlineChecksWhenNoAvailabilityFeatureNeedsThem() {
+    Config config = new Config();
+    config.copyFrom(config);
+    config.setPauseQueueIfTargetDown(false);
+    config.setKickWhenDown(false);
+
+    assertTrue(config.serversRequiringOnlineChecks().isEmpty());
+  }
+
+  @Test
+  void checksTargetServersWhenQueuePausingIsEnabled() {
+    Config config = new Config();
+    config.copyFrom(config);
+    config.setPauseQueueIfTargetDown(true);
+    config.setKickWhenDown(false);
+
+    assertEquals(Set.of("main"), config.serversRequiringOnlineChecks());
+  }
+
+  @Test
+  void checksConfiguredServersWhenDownKickingIsEnabled() {
+    Config config = new Config();
+    config.copyFrom(config);
+    config.setPauseQueueIfTargetDown(false);
+    config.setKickWhenDown(true);
+    config.setRawKickWhenDownServers(List.of("main", "queue"));
+
+    assertEquals(Set.of("main", "queue"), config.serversRequiringOnlineChecks());
+  }
+
+  @Test
   void queueTypesAreSortedByOrder() {
     Config config = createConfigWithMultipleQueueTypes();
 

--- a/shared/src/test/java/net/pistonmaster/pistonqueue/shared/queue/logic/ServerStatusManagerTest.java
+++ b/shared/src/test/java/net/pistonmaster/pistonqueue/shared/queue/logic/ServerStatusManagerTest.java
@@ -4,6 +4,8 @@ import net.pistonmaster.pistonqueue.shared.config.Config;
 import net.pistonmaster.pistonqueue.shared.queue.ServerStatusManager;
 import org.junit.jupiter.api.Test;
 
+import java.util.Set;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -55,6 +57,22 @@ class ServerStatusManagerTest {
     //now call offline once, should be offline now
     serverStatusManager.offline("testServer");
     assertTrue(serverStatusManager.getOnlineServers().isEmpty());
+  }
+
+  @Test
+  void removesStatusForServersThatNoLongerNeedChecks() {
+    Config config = QueueTestUtils.createConfigWithSingleQueueType(5);
+    config.setMinOnlineChecks(1);
+
+    QueueTestUtils.TestQueuePlugin plugin = new QueueTestUtils.TestQueuePlugin(config);
+    ServerStatusManager serverStatusManager = new ServerStatusManager(plugin::getConfiguration);
+    serverStatusManager.online("kept");
+    serverStatusManager.online("removed");
+
+    serverStatusManager.retainServers(Set.of("kept"));
+
+    assertEquals(Set.of("kept"), serverStatusManager.getOnlineServers());
+    assertEquals(0, serverStatusManager.getOnlinePingCount("removed"));
   }
 
   @Test


### PR DESCRIPTION
## Summary

- derive server checks from the availability features that are actually enabled
- stop position messages from depending on target status when queue pausing is disabled
- clear stale status entries after a live configuration reload
- compile the Velocity 4 and universal modules with their required Java 25 toolchain

## Production behavior

The current 6b6t production proxy configuration has both `pauseQueueIfTargetDown` and `kickWhenDown` disabled. With this change, its computed server check set is empty, so PistonQueue will stop pinging `main-server` and `backup-server` entirely.

If either feature is enabled later, PistonQueue automatically checks only the servers that feature needs. No configuration migration or new option is required.

## Testing

- `./gradlew spotlessApply build`
- 113 shared tests pass, including new coverage for disabled checks, each availability feature, and stale status cleanup
- the complete multi-platform build passes
